### PR TITLE
🐛Fix/warp terminal installer

### DIFF
--- a/background.sh
+++ b/background.sh
@@ -9,5 +9,5 @@ if [ ! -f "$IMAGE_PATH" ]; then
 fi
 
 gsettings set org.gnome.desktop.background picture-uri "file://$IMAGE_PATH"
-gsettings set org.gnome.desktop.background picture-options 'scaled'
+gsettings set org.gnome.desktop.background picture-options 'zoom'
 echo "Background screen set in GNOME."

--- a/install/desktop/optional/app-gitg.sh
+++ b/install/desktop/optional/app-gitg.sh
@@ -20,15 +20,15 @@ sudo apt install -y meson ninja-build git valac \
     libdazzle-1.0-dev libgpgme-dev gettext
 
 # Create a temporary directory
-TEMP_DIR=$(mktemp -d)
-gum_styled_text "Using temporary directory: $TEMP_DIR"
+gitg_temp_dir=$(mktemp -d -t gitg-XXXXXX)
+gum_styled_text "Using temporary directory: $gitg_temp_dir"
 
 # Clone the repository into the temporary directory
 gum_styled_text "Cloning the gitg repository..."
-git clone https://gitlab.gnome.org/GNOME/gitg.git "$TEMP_DIR/gitg"
+git clone https://gitlab.gnome.org/GNOME/gitg.git "$gitg_temp_dir/gitg"
 
 # Change to the repository directory
-cd "$TEMP_DIR/gitg" || { gum_styled_text "Error changing directory"; exit 1; }
+cd "$gitg_temp_dir/gitg" || { gum_styled_text "Error changing directory"; exit 1; }
 
 # Create the build directory with meson
 gum_styled_text "Configuring the build with Meson..."
@@ -44,7 +44,7 @@ sudo ninja -C build install
 
 # Clean up the temporary directory
 gum_styled_text "Cleaning up..."
-rm -rf "$TEMP_DIR"
+rm -rf "$gitg_temp_dir"
 
 gum_styled_text "Installation completed."
 

--- a/install/desktop/optional/app-gitg.sh
+++ b/install/desktop/optional/app-gitg.sh
@@ -44,6 +44,7 @@ sudo ninja -C build install
 
 # Clean up the temporary directory
 gum_styled_text "Cleaning up..."
+cd - || exit
 rm -rf "$gitg_temp_dir"
 
 gum_styled_text "Installation completed."

--- a/install/desktop/optional/app-warp-terminal.sh
+++ b/install/desktop/optional/app-warp-terminal.sh
@@ -3,9 +3,11 @@ set -e
 
 source ~/.local/share/astrolinux/gum/gum-styles.sh  # Source the styling functions.
 
-# Create a temporary directory and change to it.
-temp_dir=$(mktemp -d)
-cd "$temp_dir"
+# Create a dedicated temporary directory for Warp
+warp_temp_dir=$(mktemp -d -t warp-XXXXXX)
+gum_styled_text "Using temporary directory: $warp_temp_dir"
+
+cd "$warp_temp_dir" || { gum_styled_text "Error changing directory"; exit 1; }
 
 gum_styled_text "Installing warp terminal..."
 
@@ -29,6 +31,6 @@ sudo apt update && sudo apt install -y warp-terminal
 
 # Change back to the original directory and remove the temporary directory.
 cd - || exit  # If changing back fails, exit the script.
-rm -rf "$temp_dir"  # Remove the temporary directory.
+rm -rf "$warp_temp_dir"  # Remove the temporary directory.
 
 gum_styled_text "Warp Terminal installed successfully."

--- a/install/desktop/optional/app-warp-terminal.sh
+++ b/install/desktop/optional/app-warp-terminal.sh
@@ -1,15 +1,34 @@
 #!/bin/bash
 set -e
 
-source ~/.local/share/astrolinux/gum/gum-styles.sh
+source ~/.local/share/astrolinux/gum/gum-styles.sh  # Source the styling functions.
+
+# Create a temporary directory and change to it.
+temp_dir=$(mktemp -d)
+cd "$temp_dir"
 
 gum_styled_text "Installing warp terminal..."
 
-sudo apt-get install wget gpg
+# Ensure wget and gpg are installed.
+sudo apt-get install -y wget gpg
+
+# Download the GPG key and convert it to a suitable format.
 wget -qO- https://releases.warp.dev/linux/keys/warp.asc | gpg --dearmor > warpdotdev.gpg
+
+# Install the GPG key to the appropriate location.
 sudo install -D -o root -g root -m 644 warpdotdev.gpg /etc/apt/keyrings/warpdotdev.gpg
-sudo sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/warpdotdev.gpg] https://releases.warp.dev/linux/deb stable main" > /etc/apt/sources.list.d/warpdotdev.list'
+
+# Add the Warp terminal repository to the sources list.
+echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/warpdotdev.gpg] https://releases.warp.dev/linux/deb stable main" | sudo tee /etc/apt/sources.list.d/warpdotdev.list
+
+# Remove the temporary GPG key file.
 rm warpdotdev.gpg
-sudo apt update && sudo apt install warp-terminal
+
+# Update the package list and install the Warp terminal.
+sudo apt update && sudo apt install -y warp-terminal
+
+# Change back to the original directory and remove the temporary directory.
+cd - || exit  # If changing back fails, exit the script.
+rm -rf "$temp_dir"  # Remove the temporary directory.
 
 gum_styled_text "Warp Terminal installed successfully."


### PR DESCRIPTION
### Context

Generating the script for the gitg installation affected how the warp terminal installer was obtained in the directory where the script instance was executed.

### 🛠 Changes

- Fix installation script for Warp terminal by using a temporary directory for downloads. This ensures that the GPG key is managed properly and simplifies cleanup.
- Improved wallpaper layout
- Specific temporary directories are created for each tool.
- gitg temporary directory output is implemented so that it does not present problems in warp terminal installation

### 📘 Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

### 🧪 Test

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

### 📸 Screenshots (optional)
N/A