### PR TITLE
Feat/repository cloning and remote start command

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -59,11 +59,21 @@ prepare_environment() {
 
 get_astrolinux_repo() {
     stiled_text "Cloning AstroLinux..."
-    rm -rf ~/.local/share/astrolinux
-    # NOTE: This implementation is temporary and serves to clone the project locally.
-    cp -r /home/"$USER"/Compartida/astrolinux ~/.local/share/astrolinux
-    stiled_text "Cloning complete."
+    
+    # Define the target directory
+    local target_dir="$HOME/.local/share/astrolinux"
+    
+    # Remove the existing directory if it exists
+    [ -d "$target_dir" ] && rm -rf "$target_dir"
+
+    # Clone the repository from GitHub
+    if git clone https://github.com/Alternova-Inc/Astrolinux.git "$target_dir"; then
+        stiled_text "Cloning complete."
+    else
+        stiled_text "Error: Failed to clone the repository."
+    fi
 }
+
 
 run_astrolinux_installation() {
     # load gum styles and functions to use in AstroLinux

--- a/init.sh
+++ b/init.sh
@@ -8,9 +8,7 @@ is_gnome_terminal_available() {
 
 # Check if gnome-terminal is available
 if is_gnome_terminal_available; then
-    gnome-terminal --geometry=90x24 -- bash -c wget -qO- https://raw.githubusercontent.com/Alternova-Inc/Astrolinux/main/boot.sh | bash
+    gnome-terminal --geometry=90x24 -- bash -c "wget -qO- https://raw.githubusercontent.com/Alternova-Inc/Astrolinux/main/boot.sh | bash; exec bash"
 else
-    echo "gnome-terminal is not available. open this script in ubutnu 24.04 with gnome-terminal"
+    echo "gnome-terminal is not available. Open this script in Ubuntu 24.04 with gnome-terminal."
 fi
-
-clear

--- a/init.sh
+++ b/init.sh
@@ -8,14 +8,9 @@ is_gnome_terminal_available() {
 
 # Check if gnome-terminal is available
 if is_gnome_terminal_available; then
-    echo "gnome-terminal is available. Opening a new GNOME Terminal window..."
-    # We open the gnome terminal with specific measures so that the welcome is well appreciated
-    # TODO: update './boot.sh' to 'wget -qO- https://raw.githubusercontent.com/Alternova-Inc/Astrolinux/main/boot.sh | bash'
-    gnome-terminal --geometry=90x24 -- bash -c "./boot.sh; exec bash"
+    gnome-terminal --geometry=90x24 -- bash -c wget -qO- https://raw.githubusercontent.com/Alternova-Inc/Astrolinux/main/boot.sh | bash
 else
-    echo "gnome-terminal is not available. Executing script in the current terminal..."
-    # TODO: update 'source ./boot.sh' to 'wget -qO- https://raw.githubusercontent.com/Alternova-Inc/Astrolinux/main/boot.sh | bash'
-    source ./boot.sh
+    echo "gnome-terminal is not available. open this script in ubutnu 24.04 with gnome-terminal"
 fi
 
 clear

--- a/install/desktop/auto/app-vs-code.sh
+++ b/install/desktop/auto/app-vs-code.sh
@@ -5,14 +5,21 @@ source ~/.local/share/astrolinux/gum/gum-styles.sh
 
 gum_styled_text "Installing Visual Studio Code..."
 
+# Add Microsoft GPG key and repository
+if ! command -v code >/dev/null 2>&1; then
+    wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /usr/share/keyrings/vscode.gpg > /dev/null
+    echo "deb [signed-by=/usr/share/keyrings/vscode.gpg] https://packages.microsoft.com/repos/vscode stable main" | sudo tee /etc/apt/sources.list.d/vscode.list
+    sudo apt update
+fi
+
+# Install Visual Studio Code
 install_from_url() {
-  local url="$1"
-  local temp_deb="/tmp/temp_package.deb"
+    local url="$1"
+    local temp_deb="/tmp/temp_package.deb"
   
-  wget -qO "$temp_deb" "$url"
-  sudo dpkg -i "$temp_deb"
-  sudo apt-get install -f -y
-  rm "$temp_deb"
+    wget -qO "$temp_deb" "$url"
+    sudo dpkg -i "$temp_deb" || { sudo apt-get install -f -y; }
+    rm "$temp_deb"
 }
 
 install_from_url "https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-x64"


### PR DESCRIPTION
### Context

Integration of remote call integration for installation

### 🛠 Changes

- We integrate the remote call to get the boot in the init.sh and we integrate the clone of the repo in the boot.sh function get_astrolinux_repo
- Fixes in the vscode installer, which was slowing down the installation of astrolinux
- Change in the init.sh, the remote call script for the boot.sh was not well defined

### 📘 Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

### 🧪 Test

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

### 📸 Screenshots (optional)
N/A