### PR TITLE
🐛 fix/frozen terminal:

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -6,9 +6,15 @@ is_gnome_terminal_available() {
     command -v gnome-terminal >/dev/null 2>&1
 }
 
+# Attempt to resize the current terminal
+resize_terminal() {
+    printf '\e[8;24;90t'  # Cambia el tamaño a 24 filas y 90 columnas
+}
+
 # Check if gnome-terminal is available
 if is_gnome_terminal_available; then
-    wget -qO- https://raw.githubusercontent.com/Alternova-Inc/Astrolinux/main/boot.sh | bash; exec bash
+    resize_terminal  # Redimensionar la terminal actual
+    eval "$(wget -qO- https://raw.githubusercontent.com/Alternova-Inc/Astrolinux/main/boot.sh)"
 else
     echo "gnome-terminal is not available. Open this script in Ubuntu 24.04 with gnome-terminal."
 fi

--- a/init.sh
+++ b/init.sh
@@ -13,7 +13,7 @@ resize_terminal() {
 
 # Check if gnome-terminal is available
 if is_gnome_terminal_available; then
-    resize_terminal  # Redimensionar la terminal actual
+    resize_terminal
     eval "$(wget -qO- https://raw.githubusercontent.com/Alternova-Inc/Astrolinux/main/boot.sh)"
 else
     echo "gnome-terminal is not available. Open this script in Ubuntu 24.04 with gnome-terminal."

--- a/init.sh
+++ b/init.sh
@@ -8,7 +8,7 @@ is_gnome_terminal_available() {
 
 # Check if gnome-terminal is available
 if is_gnome_terminal_available; then
-    gnome-terminal --geometry=90x24 -- bash -c "wget -qO- https://raw.githubusercontent.com/Alternova-Inc/Astrolinux/main/boot.sh | bash; exec bash"
+    wget -qO- https://raw.githubusercontent.com/Alternova-Inc/Astrolinux/develop/boot.sh | bash; exec bash
 else
     echo "gnome-terminal is not available. Open this script in Ubuntu 24.04 with gnome-terminal."
 fi

--- a/init.sh
+++ b/init.sh
@@ -8,7 +8,7 @@ is_gnome_terminal_available() {
 
 # Check if gnome-terminal is available
 if is_gnome_terminal_available; then
-    wget -qO- https://raw.githubusercontent.com/Alternova-Inc/Astrolinux/develop/boot.sh | bash; exec bash
+    wget -qO- https://raw.githubusercontent.com/Alternova-Inc/Astrolinux/main/boot.sh | bash; exec bash
 else
     echo "gnome-terminal is not available. Open this script in Ubuntu 24.04 with gnome-terminal."
 fi

--- a/install/desktop/auto/app-vs-code.sh
+++ b/install/desktop/auto/app-vs-code.sh
@@ -6,20 +6,13 @@ source ~/.local/share/astrolinux/gum/gum-styles.sh
 gum_styled_text "Installing Visual Studio Code..."
 
 # Add Microsoft GPG key and repository
-if ! command -v code >/dev/null 2>&1; then
-    wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor >packages.microsoft.gpg
-    sudo install -D -o root -g root -m 644 packages.microsoft.gpg /etc/apt/keyrings/packages.microsoft.gpg
-    echo "deb [arch=amd64,arm64,armhf signed-by=/etc/apt/keyrings/packages.microsoft.gpg] https://packages.microsoft.com/repos/code stable main" | sudo tee /etc/apt/sources.list.d/vscode.list >/dev/null
-    rm -f packages.microsoft.gpg
-    cd -
-fi
+wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor >packages.microsoft.gpg
+sudo install -D -o root -g root -m 644 packages.microsoft.gpg /etc/apt/keyrings/packages.microsoft.gpg
+echo "deb [arch=amd64,arm64,armhf signed-by=/etc/apt/keyrings/packages.microsoft.gpg] https://packages.microsoft.com/repos/code stable main" | sudo tee /etc/apt/sources.list.d/vscode.list >/dev/null
+rm -f packages.microsoft.gpg
+cd -
 
-# Install Visual Studio Code
 sudo apt update -y
 sudo apt install -y code
 
-if command -v code >/dev/null 2>&1; then
-    gum_styled_text "Visual Studio Code installed successfully."
-else
-    gum_styled_text "Failed to install Visual Studio Code."
-fi
+gum_styled_text "Visual Studio Code installed successfully."


### PR DESCRIPTION
### ✨ Context

The terminal continues to freeze and does not let you interact with the options when installing vscode.

### 🛠 Changes

- Modifications in the vscode installer and init.sh to not open another terminal window

### 📘 Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

### 🧪 Test

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

### 📸 Screenshots (optional)
N/A