### PR TITLE
:sparkles: feat/replace logout with reboot and reorganize installatio…

### DIFF
--- a/install/desktop.sh
+++ b/install/desktop.sh
@@ -4,19 +4,21 @@ set -e
 source ~/.local/share/astrolinux/gum/gum-styles.sh
 source ~/.local/share/astrolinux/install/desktop/optional/optional-apps-menu.sh
 
-gum_styled_text "Installing applications..."
+gum_styled_text "Starting setup. Select optional applications to install, then automatic installation will begin..."
 
 # Ensure computer doesn't go to sleep or lock while installing
 gsettings set org.gnome.desktop.screensaver lock-enabled false
 gsettings set org.gnome.desktop.session idle-delay 0
 
+# optional app
+boot_optional_apps_menu
+
 # Run desktop autoinstallers
 for installer in ~/.local/share/astrolinux/install/desktop/auto/*.sh; do source "$installer"; done
-boot_optional_apps_menu
 
 # Revert to normal idle and lock settings
 gsettings set org.gnome.desktop.screensaver lock-enabled true
 gsettings set org.gnome.desktop.session idle-delay 300
 
 # Logout to pickup changes
-gum confirm "Ready to logout for all settings to take effect?" && gnome-session-quit --logout --no-prompt
+gum style --foreground 212 --bold "The system will restart in 10 seconds..." && sleep 10 && systemctl reboot


### PR DESCRIPTION
## 🎯 Milestone 
This pull request implements the following improvements in the system installation flow:

- Replaces the logout confirmation message with an automatic system reboot, including a 10-second timer before rebooting.
- Reorganizes the installation flow by moving the execution of the optional apps menu before the automatic app installation.

### 🛠 Changes
- Modified the installation flow to allow the selection of optional apps before the automatic installation.
- Added functionality to reboot the system instead of logging out.
- Adjusted the wait time before the system reboots to 10 seconds.
- Restored the default idle and lock settings after installation.

### Why is this change needed?
This change improves the user experience by ensuring that optional apps are selected before the automatic ones begin installing. Additionally, it ensures a clean system reboot to apply the changes effectively.

